### PR TITLE
Fix: Respect BaseUri when scanning in published environments

### DIFF
--- a/src/QrCodeScanner/QrCodeScanner.razor.cs
+++ b/src/QrCodeScanner/QrCodeScanner.razor.cs
@@ -9,6 +9,8 @@ namespace BlazorQrCodeScanner;
 
 public partial class QrCodeScanner:ComponentBase,IAsyncDisposable
 {
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
     [Parameter]
     public string? Class { get; set; }
 
@@ -70,11 +72,13 @@ public partial class QrCodeScanner:ComponentBase,IAsyncDisposable
     private bool onStartedCamera = false;
     protected override async Task OnInitializedAsync()
     {
-        await JSRuntime.InvokeAsync<IJSObjectReference>("import",
-                    "/_content/BlazorQrCodeScanner/html5-qrcode.min.js");
+        var baseUri = NavigationManager.BaseUri;
 
         await JSRuntime.InvokeAsync<IJSObjectReference>("import",
-                    "/_content/BlazorQrCodeScanner/qrcodeScanner.js");
+                    $"{baseUri}_content/BlazorQrCodeScanner/html5-qrcode.min.js");
+
+        await JSRuntime.InvokeAsync<IJSObjectReference>("import",
+                    $"{baseUri}_content/BlazorQrCodeScanner/qrcodeScanner.js");
 
         qrDotnetRuntimeContext = new QrDotnetRuntimeContext();
 


### PR DESCRIPTION
### Problem
When publishing, the scanner does not respect the application's base URI.  
For example, if the app is hosted at `https://localhost/APP/`, the scanner still looks for resources at `https://localhost/`.

### Fix
This pull request appends `NavigationManager.BaseUri` to ensure that URLs are resolved correctly relative to the application’s base path.

### Notes
Tested both in development and published environments. Now it works as expected under a virtual directory or base path.

Let me know if you want me to adjust anything!
